### PR TITLE
Rebuild jq 1.6 for aarch64 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   # trigger 1
   number: 1
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]
 
 outputs:
   - name: jq

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72
 
 build:
+  # trigger 1
   number: 1
 
 outputs:


### PR DESCRIPTION
Missing artifacts on `aarch64` and `s390x`:
```
https://repo.anaconda.com/pkgs/main/linux-aarch64/
 None
https://repo.anaconda.com/pkgs/main/linux-s390x/
 None
```


No actions