### PR TITLE
PKG-9937: jq 1.8.1 win

### DIFF
--- a/recipe/COPYING
+++ b/recipe/COPYING
@@ -1,0 +1,176 @@
+jq is copyright (C) 2012 Stephen Dolan
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+jq's documentation (everything found under the docs/ subdirectory in
+the source tree) is licensed under the Creative Commons CC BY 3.0
+license, which can be found at:
+
+         https://creativecommons.org/licenses/by/3.0/
+
+The documentation website includes a copy of Twitter's Bootstrap and
+relies on Bonsai, Liquid templates and various other projects, look
+them up for detailed licensing conditions.
+
+
+
+jq incorporates David M. Gay's dtoa.c and g_fmt.c, which bear the
+following notices:
+
+dtoa.c:
+The author of this software is David M. Gay.
+
+Copyright (c) 1991, 2000, 2001 by Lucent Technologies.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose without fee is hereby granted, provided that this entire notice
+is included in all copies of any software which is or includes a copy
+or modification of this software and in all copies of the supporting
+documentation for such software.
+
+THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTY.  IN PARTICULAR, NEITHER THE AUTHOR NOR LUCENT MAKES ANY
+REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY
+OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
+
+g_fmt.c:
+The author of this software is David M. Gay.
+
+Copyright (c) 1991, 1996 by Lucent Technologies.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose without fee is hereby granted, provided that this entire notice
+is included in all copies of any software which is or includes a copy
+or modification of this software and in all copies of the supporting
+documentation for such software.
+
+THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTY.  IN PARTICULAR, NEITHER THE AUTHOR NOR LUCENT MAKES ANY
+REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY
+OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
+
+
+
+jq uses parts of the open source C library "decNumber", which is distributed
+under the following license:
+
+
+ICU License - ICU 1.8.1 and later
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1995-2005 International Business Machines Corporation and others
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, provided that the above
+copyright notice(s) and this permission notice appear in all copies of
+the Software and that both the above copyright notice(s) and this
+permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL
+INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING
+FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
+WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+of the copyright holder.
+
+--------------------------------------------------------------------------------
+All trademarks and registered trademarks mentioned herein are the property of their respective owners.
+
+
+
+jv_thread.h is copied from Heimdal's lib/base/heimbase.h and some code
+in jv.c is copied from Heimdal's lib/base/dll.c:
+
+
+Portions Copyright (c) 2016 Kungliga Tekniska Högskolan
+(Royal Institute of Technology, Stockholm, Sweden).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+jq uses a modified version of NetBSD implementation strptime(),
+which is distributed under the following license:
+
+Copyright (c) 1997, 1998, 2005, 2008 The NetBSD Foundation, Inc.
+All rights reserved.
+
+This code was contributed to The NetBSD Foundation by Klaus Klein.
+Heavily optimised by David Laight
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,5 @@
+@echo off
+setlocal enabledelayedexpansion
+
+copy "%SRC_DIR%\jq-win64.exe" "%LIBRARY_BIN%\jq.exe"
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 23cb60a1354eed6bcc8d9b9735e8c7b388cd1fdcb75726b93bc299ef22dd9334  # [win]
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:  # [win]
     - vc14_runtime  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,17 +16,14 @@ source:
 
 build:
   number: 1
-  ignore_run_exports:  # [win]
-    - vc14_runtime  # [win]
 
 requirements:
   build:
-    - patch  # [linux and x86_64]
-    - {{ compiler('c') }}
-    - autoconf  # [unix]
-    - automake  # [unix]
-    - libtool  # [unix]
-    - make  # [unix]
+    - {{ compiler('c') }}  # [unix]
+    - autoconf             # [unix]
+    - automake             # [unix]
+    - libtool              # [unix]
+    - make                 # [unix]
   host:
     - oniguruma 6.9.*  # [unix]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
     - patches/0001-disable-test-no-color-on-linux-64.patch # [linux and x86_64]
 
   # Skip the Windows build because m2- and m2w64- stuff is deprecated on the defaults channel, binary repack used instead.
+  # Use the same source repo as used by MSYS2, https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-jq/PKGBUILD#L21 
   url: https://github.com/{{ name }}lang/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-win64.exe  # [win]
   sha256: 23cb60a1354eed6bcc8d9b9735e8c7b388cd1fdcb75726b93bc299ef22dd9334  # [win]
 
@@ -32,6 +33,7 @@ requirements:
 test:
   commands:
     - jq --help
+    - conda info --json | jq .platform
     - test -f ${PREFIX}/bin/jq  # [unix]
     - test -f ${PREFIX}/include/jq.h  # [unix]
     - test -f ${PREFIX}/include/jv.h  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,38 +5,42 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/{{ name }}lang/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0
-  patches:
+  url: https://github.com/{{ name }}lang/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tar.gz  # [unix]
+  sha256: 2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0  # [unix]
+  patches:  # [unix]
     - patches/0001-disable-test-no-color-on-linux-64.patch # [linux and x86_64]
+
+  # Skip the Windows build because m2- and m2w64- stuff is deprecated on the defaults channel, binary repack used instead.
+  url: https://github.com/{{ name }}lang/{{ name }}/releases/download/{{ name }}-{{ version }}/{{ name }}-win64.exe  # [win]
+  sha256: 23cb60a1354eed6bcc8d9b9735e8c7b388cd1fdcb75726b93bc299ef22dd9334  # [win]
 
 build:
   number: 0
-  # Skip the Windows support because m2- and m2w64- stuff is deprecated on the defaults channel
-  skip: True  # [win]
+  ignore_run_exports:  # [win]
+    - vc14_runtime  # [win]
 
 requirements:
   build:
     - patch  # [linux and x86_64]
     - {{ compiler('c') }}
-    - autoconf
-    - automake
-    - libtool
-    - make
+    - autoconf  # [unix]
+    - automake  # [unix]
+    - libtool  # [unix]
+    - make  # [unix]
   host:
-    - oniguruma 6.9.*
+    - oniguruma 6.9.*  # [unix]
   run:
-    - oniguruma 6.9.*
+    - oniguruma 6.9.*  # [unix]
 
 test:
   commands:
     - jq --help
-    - test -f ${PREFIX}/bin/jq
-    - test -f ${PREFIX}/include/jq.h
-    - test -f ${PREFIX}/include/jv.h
-    - test -f ${PREFIX}/lib/libjq.a
-    - test -f ${PREFIX}/lib/libjq${SHLIB_EXT}
-    - test -f ${PREFIX}/lib/pkgconfig/libjq.pc
+    - test -f ${PREFIX}/bin/jq  # [unix]
+    - test -f ${PREFIX}/include/jq.h  # [unix]
+    - test -f ${PREFIX}/include/jv.h  # [unix]
+    - test -f ${PREFIX}/lib/libjq.a  # [unix]
+    - test -f ${PREFIX}/lib/libjq${SHLIB_EXT}  # [unix]
+    - test -f ${PREFIX}/lib/pkgconfig/libjq.pc  # [unix]
 
 about:
   home: https://github.com/jqlang/jq


### PR DESCRIPTION
https://anaconda.atlassian.net/browse/PKG-9937

Client requests jq v1.8 added to the defaults channel
Client would like to have  jq v1.8 for Windows available in https://repo.anaconda.cloud/repo/main as the current version(1.6) has a CVE score of 8.1
This package is needed to create an environment and install packages from a .yml file.